### PR TITLE
TTL for system logs

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for ClickhouseDB
 
 
 type: application
-version: 0.1.9
+version: 0.2.0
 appVersion: "24.11.1-alpine"

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -39,6 +39,49 @@ config: |-
           <console>1</console>
           <log_to_syslog>false</log_to_syslog>
       </logger>
+
+      <query_log replace="1">
+        <database>system</database>
+        <table>query_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 7 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+      </query_log>
+      
+      <processors_profile_log replace="1">
+        <database>system</database>
+        <table>processors_profile_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 7 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+      </processors_profile_log>
+      
+      <trace_log replace="1">
+        <database>system</database>
+        <table>trace_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 7 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+      </trace_log>
+      
+      <part_log replace="1">
+        <database>system</database>
+        <table>part_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+      </part_log>
+      
+      <asynchronous_metric_log replace="1">
+        <database>system</database>
+        <table>asynchronous_metric_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+      </asynchronous_metric_log>
+      
+      <metric_log replace="1">
+        <database>system</database>
+        <table>metric_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+      </metric_log>
+
   </clickhouse>
 
 user: |-


### PR DESCRIPTION
Reaclaimed for demonstrator-se 
overlay          917G  476G  405G  55% from
overlay                 916.7G    782.3G     97.2G  89% /

this will not delete data automatically all tables will be renamed with _0 and the new system tables will take their place with new TTL.

also after 7 days we can delete the other ones to just leave a buffer period.

```sql
SET max_table_size_to_drop = 0;

DROP TABLE system.query_log_0;
DROP TABLE system.processors_profile_log_0;
DROP TABLE system.trace_log_0;
DROP TABLE system.part_log_0;
DROP TABLE system.asynchronous_metric_log_0;
DROP TABLE system.metric_log_0;
```

then restart clickhouse pod to reclaim the space